### PR TITLE
Allow overwriting challenge branch on a per-challenge basis

### DIFF
--- a/challenges/challenge/challenge.tf
+++ b/challenges/challenge/challenge.tf
@@ -15,7 +15,7 @@ variable "category" {
 }
 
 variable "identifier" {
-  description = "The identifier of the challenge"
+  description = "The identifier of the challenge. The identifier may contain the revision in the format of `<identifier>:<revision>`. If the revision is not specified, the variable provided revision will be used."
 }
 
 variable "path" {
@@ -54,6 +54,11 @@ variable "helm" {
   default     = null
 }
 
+locals {
+  revision = strcontains(var.identifier, ":") ? split(":", var.identifier)[1] : var.revision
+  identifier = strcontains(var.identifier, ":") ? split(":", var.identifier)[0] : var.identifier
+}
+
 module "argocd-challenge" {
   source = "../../tf-modules/argocd/application"
 
@@ -61,19 +66,19 @@ module "argocd-challenge" {
 
   argocd_namespace          = var.argocd_namespace
   application_namespace     = var.challenge_namespace
-  application_name          = var.application_name != null ? var.application_name : "${var.category}-${var.identifier}"
+  application_name          = var.application_name != null ? var.application_name : "${var.category}-${local.identifier}"
   application_repo_url      = var.application_repo_url
-  application_repo_path     = var.path != null ? var.path : "challenges/${var.category}/${var.identifier}/k8s/challenge"
-  application_repo_revision = var.revision
+  application_repo_path     = var.path != null ? var.path : "challenges/${var.category}/${local.identifier}/k8s/challenge"
+  application_repo_revision = local.revision
   application_project       = var.argocd_project
   helm                      = var.helm
 
   argocd_labels = {
     "part-of"   = "ctfpilot"
     "component" = "challenge"
-    "version"   = replace(var.revision, "/", "-")
+    "version"   = replace(local.revision, "/", "-")
     "category"  = var.category
-    "instance"  = var.identifier
+    "instance"  = local.identifier
   }
 }
 

--- a/challenges/config/config.tf
+++ b/challenges/config/config.tf
@@ -9,7 +9,7 @@ variable "category" {
 }
 
 variable "identifier" {
-  description = "The identifier of the challenge"
+  description = "The identifier of the challenge. The identifier may contain the revision in the format of `<identifier>:<revision>`. If the revision is not specified, the variable provided revision will be used."
 }
 
 variable "path" {
@@ -48,23 +48,28 @@ variable "helm" {
   default     = null
 }
 
+locals {
+  revision = strcontains(var.identifier, ":") ? split(":", var.identifier)[1] : var.revision
+  identifier = strcontains(var.identifier, ":") ? split(":", var.identifier)[0] : var.identifier
+}
+
 module "argocd-challenge-config" {
   source = "../../tf-modules/argocd/application"
 
   argocd_namespace          = var.argocd_namespace
   application_namespace     = var.config_namespace
-  application_name          = var.application_name != null ? "${var.application_name}-config" : "${var.category}-${var.identifier}-config"
+  application_name          = var.application_name != null ? "${var.application_name}-config" : "${var.category}-${local.identifier}-config"
   application_repo_url      = var.application_repo_url
-  application_repo_path     = var.path != null ? var.path : "challenges/${var.category}/${var.identifier}/k8s/config"
-  application_repo_revision = var.revision
+  application_repo_path     = var.path != null ? var.path : "challenges/${var.category}/${local.identifier}/k8s/config"
+  application_repo_revision = local.revision
   application_project       = var.argocd_project
   helm                      = var.helm
 
   argocd_labels = {
     "part-of"   = "ctfpilot"
     "component" = "challenge-config"
-    "version"   = replace(var.revision, "/", "-")
+    "version"   = replace(local.revision, "/", "-")
     "category"  = var.category
-    "instance"  = var.identifier
+    "instance"  = local.identifier
   }
 }

--- a/challenges/tfvars/template.tfvars
+++ b/challenges/tfvars/template.tfvars
@@ -43,13 +43,13 @@ chall_whitelist_ips = ["<ip1>", "<ip2>"] # List of IPs to whitelist for challeng
 
 challenges_static = {
   "<category>" = ["<challenge_slug1>", "<challenge_slug2>"],
-} # List of static challenges to deploy. Needs to be the slugs of the challenges
+} # List of static challenges to deploy. Needs to be the slugs of the challenges, in the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used.
 challenges_shared = {
   "<category>" = ["<challenge_slug1>", "<challenge_slug2>"],
-} # List of shared challenges to deploy. Needs to be the slugs of the challenges
+} # List of shared challenges to deploy. Needs to be the slugs of the challenges, in the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used.
 challenges_instanced = {
   "<category>" = ["<challenge_slug1>", "<challenge_slug2>"],
-} # List of instanced challenges to deploy. Needs to be the slugs of the challenges
+} # List of instanced challenges to deploy. Needs to be the slugs of the challenges, in the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used.
 
 challenges_repository = "<url>"    # URL of the Git repository containing the challenge definitions
 challenges_branch     = "<branch>" # Branch of the Git repository to use for the challenge definitions. Leave empty for environment based branch (environment == prod ? main : develop)

--- a/challenges/variables.tf
+++ b/challenges/variables.tf
@@ -91,19 +91,19 @@ variable "chall_whitelist_ips" {
 
 variable "challenges_static" {
   type        = map(list(string))
-  description = "List of static challenges to deploy. In the format { \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }"
+  description = "List of static challenges to deploy. In the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used."
   default     = {}
 }
 
 variable "challenges_shared" {
   type        = map(list(string))
-  description = "List of shared challenges to deploy. In the format { \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }"
+  description = "List of shared challenges to deploy. In the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used."
   default     = {}
 }
 
 variable "challenges_instanced" {
   type        = map(list(string))
-  description = "List of instanced challenges to deploy. In the format { \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }"
+  description = "List of instanced challenges to deploy. In the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used."
   default     = {}
 }
 

--- a/template.automated.tfvars
+++ b/template.automated.tfvars
@@ -264,13 +264,13 @@ chall_whitelist_ips = ["<ip1>", "<ip2>"] # List of IPs to whitelist for challeng
 
 challenges_static = {
   "<category>" = ["<challenge_slug1>", "<challenge_slug2>"],
-} # List of static challenges to deploy. Needs to be the slugs of the challenges
+} # List of static challenges to deploy. Needs to be the slugs of the challenges, in the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used.
 challenges_shared = {
   "<category>" = ["<challenge_slug1>", "<challenge_slug2>"],
-} # List of shared challenges to deploy. Needs to be the slugs of the challenges
+} # List of shared challenges to deploy. Needs to be the slugs of the challenges, in the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used.
 challenges_instanced = {
   "<category>" = ["<challenge_slug1>", "<challenge_slug2>"],
-} # List of instanced challenges to deploy. Needs to be the slugs of the challenges
+} # List of instanced challenges to deploy. Needs to be the slugs of the challenges, in the format `{ \"<category>\" = [\"<challenge_slug1>\", \"<challenge_slug2>\"] }`. Challenge slug may be defined as `<challenge_slug>:<branch>` to deploy a specific branch of the challenge. If no branch is specified, the default branch will be used.
 
 challenges_repository = "https://github.com/<repo>" # URL of the Git repository containing the challenge definitions
 challenges_branch     = ""                          # Branch of the Git repository to use for the challenge definitions. Leave empty for environment based branch (environment == prod ? main : develop)


### PR DESCRIPTION
This PR adds support for providing custom branch to deploy from, on a per-challenge basis, by adding the branch overwrite as `<slug>:<branch>`.